### PR TITLE
11/05 Server Purchasing

### DIFF
--- a/autoHack.ns
+++ b/autoHack.ns
@@ -6,7 +6,7 @@ export const main = async function(ns) {
 }
 
 function findServer(ns, startServer, targetServer, func) {
-    let servers = ns.scan(targetServer, true).filter((server) => server !== startServer);
+    let servers = ns.scan(targetServer, true).filter((server) => server !== startServer && !server.includes("Chael"));
     servers.forEach((server) => {
         func.call(this, ns, server);
         findServer(ns, targetServer, server, func);
@@ -31,45 +31,45 @@ function crackServer(ns, server) {
         return true;
     }
 
-    if(ns.fileExists('BruteSSH.exe')) {
+    if (ns.fileExists('BruteSSH.exe')) {
         ns.brutessh(server);
     }
-    if(ns.fileExists('FTPCrack.exe')) {
+    if (ns.fileExists('FTPCrack.exe')) {
         ns.ftpcrack(server);
     }
-    if(ns.fileExists('relaySMTP.exe')) {
+    if (ns.fileExists('relaySMTP.exe')) {
         ns.relaysmtp(server);
     }
-    if(ns.fileExists('HTTPWorm.exe')) {
+    if (ns.fileExists('HTTPWorm.exe')) {
         ns.httpworm(server);
     }
-    if(ns.fileExists('SQLInject.exe')) {
+    if (ns.fileExists('SQLInject.exe')) {
         ns.sqlinject(server);
     }
     if (ns.getServerRequiredHackingLevel(server) > ns.getHackingLevel() ||
         ns.getServerNumPortsRequired(server) > hackablePorts) {
         return false;
     } else {
-       ns.nuke(server);
-       return true;
+        ns.nuke(server);
+        return true;
     }
 }
 
 function findHackablePorts(ns) {
     let hackPorts = 0;
-    if(ns.fileExists('BruteSSH.exe')) {
+    if (ns.fileExists('BruteSSH.exe')) {
         hackPorts += 1;
     }
-    if(ns.fileExists('FTPCrack.exe')) {
+    if (ns.fileExists('FTPCrack.exe')) {
         hackPorts += 1;
     }
-    if(ns.fileExists('relaySMTP.exe')) {
+    if (ns.fileExists('relaySMTP.exe')) {
         hackPorts += 1;
     }
-    if(ns.fileExists('HTTPWorm.exe')) {
+    if (ns.fileExists('HTTPWorm.exe')) {
         hackPorts += 1;
     }
-    if(ns.fileExists('SQLInject.exe')) {
+    if (ns.fileExists('SQLInject.exe')) {
         hackPorts += 1;
     }
     hackablePorts = hackPorts;

--- a/autoRemoteHack.ns
+++ b/autoRemoteHack.ns
@@ -1,0 +1,25 @@
+let maxValueServers;
+
+export async function main(ns) {
+    maxValueServers = [];
+    findServer(ns, 'home', 'home', checkValue);
+    ns.tprint(maxValueServers);
+    ns.run('/scripts/remoteHack.ns', 1, ...maxValueServers);
+}
+
+function findServer(ns, startServer, targetServer, func) {
+    let servers = ns.scan(targetServer, true).filter((server) => server !== startServer && !server.includes("Chael"));
+    if (!ns.hasRootAccess(targetServer)) { return false; }
+    servers.forEach((server) => {
+        func.call(this, ns, server);
+        if (ns.hasRootAccess(server)) {
+            findServer(ns, targetServer, server, func);
+        }
+    });
+}
+
+function checkValue(ns, server) {
+    if(ns.getServerMaxMoney(server) > 10000000000 && ns.hasRootAccess(server)) {
+        maxValueServers.push(server);
+    }
+}

--- a/dashboard.ns
+++ b/dashboard.ns
@@ -8,8 +8,16 @@ export async function main(ns) {
     if (hackableServers) {
         let runAutoHack = await ns.prompt("Would you like to hack available servers?");
         if (runAutoHack) {
+            ns.tprint("hacking");
             ns.run('/scripts/autoHack.ns');
+            ns.tprint("hacked");
         }
+    }
+    let purchaseServers = await ns.prompt("Would you like to purchase servers?");
+    if (purchaseServers) { ns.run('/scripts/purchaseServers.ns'); }
+    if (purchaseServers || runAutoHack) {
+        let remoteHack = await ns.prompt("Would you like to refresh your remote attacks?");
+        if (remoteHack) { ns.run('/scripts/autoRemoteHack.ns'); }
     }
 }
 
@@ -34,7 +42,7 @@ function findHackablePorts(ns) {
 }
 
 function findServer(ns, startServer, targetServer, func) {
-    let servers = ns.scan(targetServer, true).filter((server) => server !== startServer);
+    let servers = ns.scan(targetServer, true).filter((server) => server !== startServer && !server.includes("Chael"));
     servers.forEach((server) => {
         func.call(this, ns, server);
         if (serverStatus(ns, server) !== "🔐") {

--- a/purchaseServers.ns
+++ b/purchaseServers.ns
@@ -1,0 +1,65 @@
+let maxServers;
+let servers;
+
+export async function main(ns) {
+    // Default Values
+    maxServers = ns.getPurchasedServerLimit();
+    servers = ns.getPurchasedServers(true);
+    serverInfo(ns);
+    await buyServers(ns);
+}
+
+function serverInfo(ns) {
+   ns.tprint(`You have ${servers.length}/${maxServers} servers`);
+   Object.entries(groupServers(ns)).map((ramServers) => {
+      ns.tprint(`${ramServers[0]}GB: ${ramServers[1]}`); 
+   });
+}
+
+function groupServers(ns) {
+    let groupedServers = {};
+    servers.forEach((server) => {
+        let ram = ns.getServerRam(server)[0];
+        groupedServers[ram] = groupedServers[ram] || [];
+        groupedServers[ram].push(server);
+    });
+    return groupedServers;
+}
+
+async function buyServers(ns) {
+    let ram = ns.getPurchasedServerMaxRam();
+    let shopServer = true;
+    while (shopServer) {
+        let myMoney = ns.getServerMoneyAvailable('home');
+        let serverCost = ns.getPurchasedServerCost(ram);
+        while (serverCost > myMoney && ram > 2) {
+            ram = ram / 2;
+            serverCost = ns.getPurchasedServerCost(ram);
+        }
+        shopServer = await ns.prompt(`Would you like to buy a ${ram}GB server for ${ns.nFormat(serverCost, "$0.00a")}`);
+        if (shopServer) { shopServer = buyServer(ns, ram); }
+    }
+}
+
+function buyServer(ns, ram) {
+    if (servers.length == maxServers) {
+        let success = removeWeakestServer(ns, ram);
+        if (!success) { return false; }
+    }
+    let server = ns.purchaseServer(`ChaelPwns-${ram}GB`, ram);
+    servers.push(server);
+    ns.tprint(`Purchased ${server}: ${ram}GB`);
+    return true;
+}
+
+function removeWeakestServer(ns, newRam) {
+    let groupedServers = groupServers(ns);
+    let min = Math.min(...Object.keys(groupedServers));
+    if (min >= newRam) {
+        ns.tprint(`Your smallest server has ${min}GB RAM and you wanted to purchase ${newRam}GB server`);
+        return false;
+    }
+    ns.deleteServer(groupedServers[min][0]);
+    servers = ns.getPurchasedServers(true);
+    return true;
+}

--- a/remoteHack.ns
+++ b/remoteHack.ns
@@ -1,0 +1,17 @@
+export async function main(ns) {
+  let myServers = ns.getPurchasedServers();
+  let targetServers = ns.args;
+  myServers.map((server, index) => {
+    ns.killall(server);
+    let scriptRam = ns.getScriptRam('/scripts/hack.ns');
+    let serverRam = ns.getServerRam(server)[0];
+    let threads = Math.floor(serverRam / scriptRam);
+    let serverIndex = index % targetServers.length;
+    let targetServer = targetServers[serverIndex];
+    ns.tprint(`${server} is hacking ${targetServer} with ${threads} threads.`);
+    ns.scp('/scripts/hack.ns', server);
+    if (threads > 0) {
+        ns.exec('/scripts/hack.ns', server, threads, targetServer, threads);
+    }
+  });
+}


### PR DESCRIPTION
- Add remoteHack.ns
   - Accepts an array of servers
   - Distributes hackable servers across all purchased servers
   - Calculates the appropriate number of threads
   - Distributes the latest version of hack.ns and executes it
- Add autoRemoteHack.ns
   - creates a list of hackable servers worth more than $10b
   - remotely hacks them using remoteHack.ns
- purchaseServers.ns
   - reports on existing servers
   - purchases the best quality server you can buy
   - asks and receives confirmation before spending money
   - destroys the smallest server when the server cap is reached
- Dashboard will trigger purchaseServers and call autoRemoteHack
- autoHack.ns and dashboard.ns will not run on purchasedServers.