### PR TITLE
add autocomplete and upgrade hacknet nodes

### DIFF
--- a/scripts/hax.js
+++ b/scripts/hax.js
@@ -36,6 +36,10 @@ async function runCommand(ns, command) {
     case 'purchaseHacknet':
       ns.run(`/${getFolder()}/buyHacknet.js`, 1, 'buyNode');
       break;
+    case 'upgradeHacknet':
+      ns.run(`/${getFolder()}/buyHacknet.js`, 1, 'buyNode');
+      ns.run(`/${getFolder()}/buyHacknet.js`, 1, 'upgradeNodes');
+      break;
     case 'buyServer':
     case 'purchaseServer':
     case 'buyServers':
@@ -54,4 +58,8 @@ async function indecisiveBuyer(ns) {
     ns.run(`/${getFolder()}/buyHacknet.js`, 1, 'buyNode');
     ns.tprint(`You've bought a node. See \`run /${getFolder()}/buyHacknet.js\` for more options.`);
   }
+}
+
+export function autocomplete(data, args){
+  return ['autoHack', 'autoRemoteHack','dashboard','buy', 'purchaseServer', 'buyHacknet', 'upgradeHacknet'];
 }


### PR DESCRIPTION
closes #7

added autocomplete for easier use with `alias()`
upgrade hacknet nodes to buy & upgrade hacknet nodes (still can't decide which should be first, buy new nodes or upgrade nodes)