### PR TITLE
Update remoteHack to work with v2 API

### DIFF
--- a/scripts/remoteHack.js
+++ b/scripts/remoteHack.js
@@ -1,25 +1,26 @@
 import { getHackScript } from 'import.js';
 
 /* Deploys the hack script to all purchased servers
- * Differs from autoRemotHack because you can specify
+ * Differs from autoRemoteHack because you can specify
  * the target
  * args[0] - list of servers
+ * args[1] - alternate Hackscript (default from import)
  */
 export async function main(ns) {
   let myServers = ns.getPurchasedServers();
   let targetServers = ns.args[0].split(',');
   let hackScript = ns.args[1] || getHackScript();
-  myServers.map((server, index) => {
+  let scriptRam = ns.getScriptRam(hackScript);
+  for (const [index, server] of myServers.entries()) {
     ns.killall(server);
-    let scriptRam = ns.getScriptRam(hackScript);
     let serverRam = ns.getServerRam(server)[0];
     let threads = Math.floor(serverRam / scriptRam);
     let serverIndex = index % targetServers.length;
     let targetServer = targetServers[serverIndex];
-    ns.tprint(`${server} is hacking ${targetServer} with ${threads} threads.`);
-    ns.scp(hackScript, server);
+    ns.print(`${server} is hacking ${targetServer} with ${threads} threads.`);
+    await ns.scp(hackScript, server);
     if (threads > 0) {
       ns.exec(hackScript, server, threads, targetServer, threads);
     }
-  });
+  }
 }


### PR DESCRIPTION
closes #9 

# Description
With the updates to BitBurner's v2 API, `scp` now requires an `await`.

# Changes
Updated remoteHack to comply with this API!
`hax autoRemoteHack` should now work.